### PR TITLE
fix: 연동 프로세스 플로우차트 오렌지 스타일 통일

### DIFF
--- a/src/docs/pg/01-getting-started.mdx
+++ b/src/docs/pg/01-getting-started.mdx
@@ -111,31 +111,31 @@ SETTLE_PG.pay({
 <div className="bg-gray-50 p-6 rounded-xl my-8">
   <div className="flex items-center justify-between">
     <div className="flex flex-col items-center text-center">
-      <div className="w-12 h-12 bg-hecto-400 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">1</div>
+      <div className="w-12 h-12 bg-orange-500 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">1</div>
       <span className="text-sm font-medium text-gray-700">결제 요청</span>
       <span className="text-xs text-gray-500">가맹점→PG</span>
     </div>
-    <div className="flex-1 h-0.5 bg-hecto-200 mx-4"></div>
+    <div className="flex-1 h-0.5 bg-orange-200 mx-4"></div>
     <div className="flex flex-col items-center text-center">
-      <div className="w-12 h-12 bg-hecto-400 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">2</div>
+      <div className="w-12 h-12 bg-orange-500 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">2</div>
       <span className="text-sm font-medium text-gray-700">결제창 표시</span>
       <span className="text-xs text-gray-500">PG→고객</span>
     </div>
-    <div className="flex-1 h-0.5 bg-hecto-200 mx-4"></div>
+    <div className="flex-1 h-0.5 bg-orange-200 mx-4"></div>
     <div className="flex flex-col items-center text-center">
-      <div className="w-12 h-12 bg-hecto-400 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">3</div>
+      <div className="w-12 h-12 bg-orange-500 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">3</div>
       <span className="text-sm font-medium text-gray-700">정보 입력</span>
       <span className="text-xs text-gray-500">고객 결제</span>
     </div>
-    <div className="flex-1 h-0.5 bg-hecto-200 mx-4"></div>
+    <div className="flex-1 h-0.5 bg-orange-200 mx-4"></div>
     <div className="flex flex-col items-center text-center">
-      <div className="w-12 h-12 bg-hecto-400 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">4</div>
+      <div className="w-12 h-12 bg-orange-500 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">4</div>
       <span className="text-sm font-medium text-gray-700">승인 처리</span>
       <span className="text-xs text-gray-500">카드사 승인</span>
     </div>
-    <div className="flex-1 h-0.5 bg-hecto-200 mx-4"></div>
+    <div className="flex-1 h-0.5 bg-orange-200 mx-4"></div>
     <div className="flex flex-col items-center text-center">
-      <div className="w-12 h-12 bg-hecto-400 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">5</div>
+      <div className="w-12 h-12 bg-orange-500 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">5</div>
       <span className="text-sm font-medium text-gray-700">결과 통보</span>
       <span className="text-xs text-gray-500">PG→가맹점</span>
     </div>


### PR DESCRIPTION
## 🎨 변경사항

### 문제점
- 시작하기 문서의 플로우차트가 포인트 다모아 문서와 다른 색상으로 되어 있어 일관성 부족

### 해결책
- ✅ **색상 통일**: 포인트 다모아 문서와 동일한 **orange-500** 색상 적용
- ✅ **연결선 통일**: **orange-200** 색상으로 연결선 변경
- ✅ **디자인 일관성**: 전체 문서의 시각적 통일성 확보

### 적용된 변경사항
- 모든 단계 원형 아이콘:  → 
- 연결선:  → 
- 포인트 다모아 문서 플로우차트와 완전히 동일한 스타일

## 🎯 효과
- 📚 **문서 일관성**: 모든 결제 수단 문서 간 통일된 디자인
- 🧡 **브랜드 정체성**: 일관된 오렌지 컬러 스킴
- 👀 **사용자 경험**: 예측 가능하고 친숙한 인터페이스

## 🔍 참조
- 포인트 다모아 문서 (src/docs/pg/07-point-damoa.mdx, 114-140라인) 스타일 기준
- 동일한 bg-gray-50 배경에 orange-500 아이콘 구성

## ✅ 테스트
- [x] 색상 변경 적용 완료
- [x] 포인트 다모아 문서와 스타일 일치 확인
- [x] 반응형 레이아웃 정상 작동