### PR TITLE
feat: 메인 문서 레이아웃 플렉시블 개선

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -62,7 +62,7 @@ export default function Layout({ children }: LayoutProps) {
           <div className="flex justify-between items-center h-16">
             {/* Logo */}
             <Link to="/" className="flex items-center hover:opacity-80 transition-opacity -ml-4">
-              <img src="/site-mark.svg" alt="헥토파이낸셜" className="h-8" />
+              <img src="/site-mark.svg" alt="헥토파이낸셜" className="h-8" /> 
             </Link>
 
             {/* Desktop Navigation */}
@@ -238,17 +238,17 @@ export default function Layout({ children }: LayoutProps) {
             </div>
             
             {/* Content Area */}
-            <div className="flex-1 min-w-0 max-w-4xl lg:mr-64">
+            <div className="flex-1 min-w-0 lg:mr-56">
               <div className="w-full px-4 sm:px-6 lg:px-8 py-4">
                 {/* Documentation Content */}
-                <div className="w-full max-w-2xl overflow-x-hidden">
+                <div className="w-full overflow-x-hidden">
                   {children}
                 </div>
               </div>
             </div>
             
             {/* Table of Contents - Fixed to right edge */}
-            <div className="hidden lg:block fixed right-0 top-20 w-64 h-[calc(100vh-5rem)] overflow-y-auto bg-white border-l border-gray-200 p-4">
+            <div className="hidden lg:block fixed right-0 top-20 w-56 h-[calc(100vh-5rem)] overflow-y-auto bg-white border-l border-gray-200 p-4">
               <TableOfContents />
             </div>
           </div>


### PR DESCRIPTION
## 🔧 주요 변경사항

### 플렉시블한 콘텐츠 영역
- 고정 너비 제거 (max-w-4xl, max-w-2xl)
- 화면 크기에 따라 자동 조정되는 레이아웃

### 목차 최적화  
- 목차 너비: w-64 → w-56
- 콘텐츠 마진: lg:mr-64 → lg:mr-56
- 목차와 콘텐츠 겹침 방지

## 📊 변경사항
- **파일**: src/components/Layout.tsx
- **결과**: 더 넓고 균형잡힌 콘텐츠 영역