### PR TITLE
feat: 헤더 레이아웃 왼쪽 정렬 개선

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -58,10 +58,10 @@ export default function Layout({ children }: LayoutProps) {
     <div className="min-h-screen bg-white">
       {/* Header */}
       <header className="bg-white shadow-sm border-b border-gray-100">
-        <div className="max-w-7xl mx-auto pl-0 pr-4">
-          <div className="flex justify-between items-center h-16">
+        <div className="w-full pl-6 pr-4">
+          <div className="flex justify-start items-center h-16 space-x-8">
             {/* Logo */}
-            <Link to="/" className="flex items-center hover:opacity-80 transition-opacity -ml-4">
+            <Link to="/" className="flex items-center hover:opacity-80 transition-opacity">
               <img src="/site-mark.svg" alt="헥토파이낸셜" className="h-8" /> 
             </Link>
 


### PR DESCRIPTION
## 🔧 주요 변경사항

### 헤더 레이아웃 개선
- 로고와 네비게이션 메뉴를 화면 왼쪽에 정렬
- 고정 너비 제거하여 플렉시블한 레이아웃 구현

### 여백 및 간격 조정
- 로고 왼쪽 여백: 24px (pl-6)
- 로고와 메뉴 간격: 32px (space-x-8)
- justify-between → justify-start로 변경

## 📊 변경사항
- **파일**: src/components/Layout.tsx
- **결과**: 더 모던하고 일관된 왼쪽 정렬 레이아웃