### PR TITLE
feat: 연동 가이드 문서 색상을 헥토 오렌지 톤으로 통일

### DIFF
--- a/src/docs/pg/01-getting-started.mdx
+++ b/src/docs/pg/01-getting-started.mdx
@@ -25,25 +25,25 @@ import { FeatureGrid, TestScenario, ErrorGuide, NextSteps, DocumentFooter } from
     icon: "🔒",
     title: "강력한 보안",
     description: "PCI DSS 준수, AES-256 암호화, 해시 검증으로 안전한 결제 환경 제공",
-    bgColor: "from-blue-50 to-blue-100",
-    borderColor: "border-blue-200",
-    iconBgColor: "bg-blue-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "⚡",
     title: "빠른 연동",
     description: "표준 API와 SDK를 통한 쉽고 빠른 연동, 샘플 코드 제공",
-    bgColor: "from-green-50 to-green-100",
-    borderColor: "border-green-200",
-    iconBgColor: "bg-green-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "📊",
     title: "실시간 관리",
     description: "실시간 거래 조회, 정산 관리, 상세한 통계 데이터 제공",
-    bgColor: "from-purple-50 to-purple-100",
-    borderColor: "border-purple-200",
-    iconBgColor: "bg-purple-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   }
 ]} />
 
@@ -168,13 +168,13 @@ SETTLE_PG.pay({
 **핵심 URL 3종세트:**
 
 <div className="grid grid-cols-1 md:grid-cols-3 gap-4 my-6">
-  <div className="bg-blue-50 border border-blue-200 p-4 rounded-lg">
+  <div className="bg-blue-50 border border-hecto-200 p-4 rounded-lg">
     <h4 className="font-semibold text-blue-900 mb-2">🔔 notiUrl</h4>
     <p className="text-sm text-blue-800">Server-to-Server 결과 통보</p>
     <p className="text-xs text-blue-600 mt-2">💡 실제 DB 처리는 여기서!</p>
   </div>
   
-  <div className="bg-green-50 border border-green-200 p-4 rounded-lg">
+  <div className="bg-green-50 border border-hecto-200 p-4 rounded-lg">
     <h4 className="font-semibold text-green-900 mb-2">✅ nextUrl</h4>
     <p className="text-sm text-green-800">결제 완료 후 고객 화면</p>
     <p className="text-xs text-green-600 mt-2">💡 화면 표시용으로만 사용</p>
@@ -525,7 +525,7 @@ const pktHash = generateHash(hashData);
   
   <a href="/docs/pg/virtual-account" className="block p-4 bg-white border-2 border-green-100 hover:border-green-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-green-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-green-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-green-600 transition-colors">
         <span className="text-white text-lg">💰</span>
       </div>
       <span className="text-sm font-medium text-gray-900">가상계좌</span>
@@ -534,7 +534,7 @@ const pktHash = generateHash(hashData);
   
   <a href="/docs/pg/bank-transfer" className="block p-4 bg-white border-2 border-blue-100 hover:border-blue-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-blue-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-blue-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-blue-600 transition-colors">
         <span className="text-white text-lg">🏦</span>
       </div>
       <span className="text-sm font-medium text-gray-900">계좌이체</span>
@@ -543,7 +543,7 @@ const pktHash = generateHash(hashData);
   
   <a href="/docs/pg/mobile-payment" className="block p-4 bg-white border-2 border-purple-100 hover:border-purple-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-purple-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-purple-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-purple-600 transition-colors">
         <span className="text-white text-lg">📱</span>
       </div>
       <span className="text-sm font-medium text-gray-900">휴대폰</span>

--- a/src/docs/pg/02-credit-card.mdx
+++ b/src/docs/pg/02-credit-card.mdx
@@ -29,17 +29,17 @@ import { FeatureGrid, TestScenario, ErrorGuide, NextSteps, DocumentFooter } from
     icon: "📅",
     title: "할부 결제",
     description: "다양한 할부 옵션으로 고객 편의성 제공",
-    bgColor: "from-emerald-50 to-emerald-100",
-    borderColor: "border-emerald-200",
-    iconBgColor: "bg-emerald-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "🔄",
     title: "정기 결제",
     description: "빌키 서비스로 편리한 정기 결제 관리",
-    bgColor: "from-violet-50 to-violet-100",
-    borderColor: "border-violet-200",
-    iconBgColor: "bg-violet-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   }
 ]} />
 
@@ -676,7 +676,7 @@ A. 원거래 금액 범위 내에서 여러 번 부분취소가 가능합니다.
       bgColor: "bg-white",
       borderColor: "border-green-100",
       hoverBorderColor: "border-green-300",
-      iconBgColor: "bg-green-500",
+      iconBgColor: "bg-hecto-400",
       hoverIconBgColor: "bg-green-600"
     },
     {
@@ -686,7 +686,7 @@ A. 원거래 금액 범위 내에서 여러 번 부분취소가 가능합니다.
       bgColor: "bg-white",
       borderColor: "border-blue-100",
       hoverBorderColor: "border-blue-300",
-      iconBgColor: "bg-blue-500",
+      iconBgColor: "bg-hecto-400",
       hoverIconBgColor: "bg-blue-600"
     },
     {
@@ -696,7 +696,7 @@ A. 원거래 금액 범위 내에서 여러 번 부분취소가 가능합니다.
       bgColor: "bg-white",
       borderColor: "border-purple-100",
       hoverBorderColor: "border-purple-300",
-      iconBgColor: "bg-purple-500",
+      iconBgColor: "bg-hecto-400",
       hoverIconBgColor: "bg-purple-600"
     },
     {

--- a/src/docs/pg/03-virtual-account.mdx
+++ b/src/docs/pg/03-virtual-account.mdx
@@ -13,9 +13,9 @@ import { FeatureGrid, TestScenario, ErrorGuide, NextSteps, DocumentFooter } from
     icon: "🏦",
     title: "다양한 은행",
     description: "국내 주요 금융기관 모두 지원, 넓은 은행 네트워크",
-    bgColor: "from-emerald-50 to-emerald-100",
-    borderColor: "border-emerald-200",
-    iconBgColor: "bg-emerald-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "📱",
@@ -29,9 +29,9 @@ import { FeatureGrid, TestScenario, ErrorGuide, NextSteps, DocumentFooter } from
     icon: "⏰",
     title: "유연한 기한",
     description: "설정 가능한 만료 기한, 자동 만료 처리",
-    bgColor: "from-violet-50 to-violet-100",
-    borderColor: "border-violet-200",
-    iconBgColor: "bg-violet-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "⚡",
@@ -660,7 +660,7 @@ A. 가상계좌 환불 API를 통해 고객의 계좌로 직접 환불할 수 �
       bgColor: "bg-white",
       borderColor: "border-blue-100",
       hoverBorderColor: "border-blue-300",
-      iconBgColor: "bg-blue-500",
+      iconBgColor: "bg-hecto-400",
       hoverIconBgColor: "bg-blue-600"
     },
     {
@@ -670,7 +670,7 @@ A. 가상계좌 환불 API를 통해 고객의 계좌로 직접 환불할 수 �
       bgColor: "bg-white",
       borderColor: "border-purple-100",
       hoverBorderColor: "border-purple-300",
-      iconBgColor: "bg-purple-500",
+      iconBgColor: "bg-hecto-400",
       hoverIconBgColor: "bg-purple-600"
     },
     {
@@ -693,7 +693,7 @@ A. 가상계좌 환불 API를 통해 고객의 계좌로 직접 환불할 수 �
   primaryButton={{
     text: "📧 기술지원 문의",
     href: "mailto:support@hectofinancial.com",
-    bgColor: "bg-green-500",
+    bgColor: "bg-hecto-400",
     hoverBgColor: "hover:bg-green-600"
   }}
   secondaryButton={{

--- a/src/docs/pg/04-bank-transfer.mdx
+++ b/src/docs/pg/04-bank-transfer.mdx
@@ -13,25 +13,25 @@ import { FeatureGrid, TestScenario, ErrorGuide, NextSteps, DocumentFooter } from
     icon: "⚡",
     title: "실시간 결제",
     description: "뱅크페이 시스템을 통한 즉시 계좌이체, 실시간 승인 처리",
-    bgColor: "from-blue-50 to-blue-100",
-    borderColor: "border-blue-200",
-    iconBgColor: "bg-blue-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "🏦",
     title: "다양한 은행 지원",
     description: "국내 주요 은행 모두 지원, 인터넷뱅킹 및 모바일뱅킹 연동",
-    bgColor: "from-green-50 to-green-100",
-    borderColor: "border-green-200",
-    iconBgColor: "bg-green-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "🧾",
     title: "현금영수증 자동발행",
     description: "결제 완료 시 현금영수증이 자동으로 발행되어 세무 처리 편리",
-    bgColor: "from-purple-50 to-purple-100",
-    borderColor: "border-purple-200",
-    iconBgColor: "bg-purple-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "🔒",
@@ -108,25 +108,25 @@ SETTLE_PG.pay({
 <div className="bg-gray-50 p-6 rounded-xl my-8">
   <div className="flex items-center justify-between">
     <div className="flex flex-col items-center text-center">
-      <div className="w-12 h-12 bg-blue-500 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">1</div>
+      <div className="w-12 h-12 bg-hecto-400 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">1</div>
       <span className="text-sm font-medium text-gray-700">결제 요청</span>
       <span className="text-xs text-gray-500">가맹점→PG</span>
     </div>
     <div className="flex-1 h-0.5 bg-blue-200 mx-4"></div>
     <div className="flex flex-col items-center text-center">
-      <div className="w-12 h-12 bg-blue-500 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">2</div>
+      <div className="w-12 h-12 bg-hecto-400 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">2</div>
       <span className="text-sm font-medium text-gray-700">은행 선택</span>
       <span className="text-xs text-gray-500">고객 선택</span>
     </div>
     <div className="flex-1 h-0.5 bg-blue-200 mx-4"></div>
     <div className="flex flex-col items-center text-center">
-      <div className="w-12 h-12 bg-blue-500 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">3</div>
+      <div className="w-12 h-12 bg-hecto-400 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">3</div>
       <span className="text-sm font-medium text-gray-700">인증 및 이체</span>
       <span className="text-xs text-gray-500">뱅크페이</span>
     </div>
     <div className="flex-1 h-0.5 bg-blue-200 mx-4"></div>
     <div className="flex flex-col items-center text-center">
-      <div className="w-12 h-12 bg-blue-500 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">4</div>
+      <div className="w-12 h-12 bg-hecto-400 rounded-full flex items-center justify-center text-white font-bold text-lg mb-2">4</div>
       <span className="text-sm font-medium text-gray-700">결제 완료</span>
       <span className="text-xs text-gray-500">즉시 승인</span>
     </div>
@@ -661,7 +661,7 @@ A. 뱅크페이에 등록된 가맹점명이 표시됩니다. 변경이 필요�
       bgColor: "bg-white",
       borderColor: "border-green-100",
       hoverBorderColor: "border-green-300",
-      iconBgColor: "bg-green-500",
+      iconBgColor: "bg-hecto-400",
       hoverIconBgColor: "bg-green-600"
     },
     {
@@ -671,7 +671,7 @@ A. 뱅크페이에 등록된 가맹점명이 표시됩니다. 변경이 필요�
       bgColor: "bg-white",
       borderColor: "border-purple-100",
       hoverBorderColor: "border-purple-300",
-      iconBgColor: "bg-purple-500",
+      iconBgColor: "bg-hecto-400",
       hoverIconBgColor: "bg-purple-600"
     },
     {
@@ -694,7 +694,7 @@ A. 뱅크페이에 등록된 가맹점명이 표시됩니다. 변경이 필요�
   primaryButton={{
     text: "📧 기술지원 문의",
     href: "mailto:support@hectofinancial.com",
-    bgColor: "bg-blue-500",
+    bgColor: "bg-hecto-400",
     hoverBgColor: "hover:bg-blue-600"
   }}
   secondaryButton={{

--- a/src/docs/pg/05-mobile-payment.mdx
+++ b/src/docs/pg/05-mobile-payment.mdx
@@ -13,25 +13,25 @@ import { FeatureGrid, TestScenario, ErrorGuide, NextSteps, DocumentFooter } from
     icon: "📞",
     title: "간편 인증",
     description: "휴대폰 번호와 생년월일만으로 간단한 본인 인증 및 결제",
-    bgColor: "from-purple-50 to-purple-100",
-    borderColor: "border-purple-200",
-    iconBgColor: "bg-purple-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "📡",
     title: "모든 통신사 지원",
     description: "SKT, KT, LG U+, 알뜰폰 등 모든 국내 통신사 지원",
-    bgColor: "from-blue-50 to-blue-100",
-    borderColor: "border-blue-200",
-    iconBgColor: "bg-blue-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "🔄",
     title: "정기결제",
     description: "월자동 결제 서비스로 구독 서비스에 최적화",
-    bgColor: "from-green-50 to-green-100",
-    borderColor: "border-green-200",
-    iconBgColor: "bg-green-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "⚡",
@@ -716,7 +716,7 @@ const refundRequest = {
 ### 🎯 테스트 시나리오
 
 <div className="grid grid-cols-1 md:grid-cols-2 gap-6 my-8">
-  <div className="bg-green-50 border border-green-200 p-6 rounded-xl">
+  <div className="bg-green-50 border border-hecto-200 p-6 rounded-xl">
     <h4 className="text-green-900 font-semibold mb-3">✅ 성공 시나리오</h4>
     <ul className="text-green-800 text-sm space-y-2">
       <li>• 일반 휴대폰 결제</li>
@@ -811,7 +811,7 @@ A. 네, CJ헬로모바일, 한국케이블텔레콤 등 주요 알뜰폰 서비�
   
   <a href="/docs/pg/virtual-account" className="block p-4 bg-white border-2 border-green-100 hover:border-green-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-green-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-green-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-green-600 transition-colors">
         <span className="text-white text-lg">💰</span>
       </div>
       <span className="text-sm font-medium text-gray-900">가상계좌</span>
@@ -820,7 +820,7 @@ A. 네, CJ헬로모바일, 한국케이블텔레콤 등 주요 알뜰폰 서비�
   
   <a href="/docs/pg/bank-transfer" className="block p-4 bg-white border-2 border-blue-100 hover:border-blue-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-blue-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-blue-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-blue-600 transition-colors">
         <span className="text-white text-lg">🏦</span>
       </div>
       <span className="text-sm font-medium text-gray-900">계좌이체</span>
@@ -844,7 +844,7 @@ A. 네, CJ헬로모바일, 한국케이블텔레콤 등 주요 알뜰폰 서비�
     휴대폰 결제 연동에 대한 추가 문의사항이 있으시나요?
   </p>
   <div className="flex justify-center space-x-4">
-    <a href="mailto:support@hectofinancial.com" className="inline-flex items-center px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 transition-colors">
+    <a href="mailto:support@hectofinancial.com" className="inline-flex items-center px-4 py-2 bg-hecto-400 text-white rounded-lg hover:bg-purple-600 transition-colors">
       📧 기술지원 문의
     </a>
     <a href="/docs/pg/api-reference" className="inline-flex items-center px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors">

--- a/src/docs/pg/06-gift-card.mdx
+++ b/src/docs/pg/06-gift-card.mdx
@@ -21,25 +21,25 @@ import { FeatureGrid, TestScenario, ErrorGuide, NextSteps, DocumentFooter } from
     icon: "💳",
     title: "간편 결제",
     description: "상품권 번호와 PIN 입력만으로 간단한 결제",
-    bgColor: "from-blue-50 to-blue-100",
-    borderColor: "border-blue-200",
-    iconBgColor: "bg-blue-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "🔄",
     title: "실시간 처리",
     description: "즉시 잔액 확인 및 결제 승인 처리",
-    bgColor: "from-green-50 to-green-100",
-    borderColor: "border-green-200",
-    iconBgColor: "bg-green-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "🛡️",
     title: "안전한 거래",
     description: "상품권 유효성 검증 및 중복 사용 방지",
-    bgColor: "from-purple-50 to-purple-100",
-    borderColor: "border-purple-200",
-    iconBgColor: "bg-purple-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   }
 ]} />
 
@@ -743,7 +743,7 @@ A. 네, 모든 지원 상품권은 실시간으로 잔액 확인 및 차감 처�
       bgColor: "bg-white",
       borderColor: "border-purple-100",
       hoverBorderColor: "border-purple-300",
-      iconBgColor: "bg-purple-500",
+      iconBgColor: "bg-hecto-400",
       hoverIconBgColor: "bg-purple-600"
     },
     {
@@ -753,7 +753,7 @@ A. 네, 모든 지원 상품권은 실시간으로 잔액 확인 및 차감 처�
       bgColor: "bg-white",
       borderColor: "border-green-100",
       hoverBorderColor: "border-green-300",
-      iconBgColor: "bg-green-500",
+      iconBgColor: "bg-hecto-400",
       hoverIconBgColor: "bg-green-600"
     },
     {

--- a/src/docs/pg/07-point-damoa.mdx
+++ b/src/docs/pg/07-point-damoa.mdx
@@ -21,25 +21,25 @@ import { FeatureGrid, TestScenario, ErrorGuide, NextSteps, DocumentFooter } from
     icon: "🔐",
     title: "본인 인증",
     description: "CI(고객식별정보) 기반의 안전한 본인 인증 시스템",
-    bgColor: "from-blue-50 to-blue-100",
-    borderColor: "border-blue-200",
-    iconBgColor: "bg-blue-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "⚡",
     title: "실시간 처리",
     description: "포인트 잔액 확인부터 결제 완료까지 실시간 처리",
-    bgColor: "from-green-50 to-green-100",
-    borderColor: "border-green-200",
-    iconBgColor: "bg-green-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "📊",
     title: "포인트 관리",
     description: "포인트 적립, 사용, 잔액 조회 등 종합적인 포인트 관리",
-    bgColor: "from-purple-50 to-purple-100",
-    borderColor: "border-purple-200",
-    iconBgColor: "bg-purple-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   }
 ]} />
 
@@ -734,7 +734,7 @@ function validateCustomerInfo(customerData) {
 ### 🎯 테스트 시나리오
 
 <div className="grid grid-cols-1 md:grid-cols-2 gap-6 my-8">
-  <div className="bg-green-50 border border-green-200 p-6 rounded-xl">
+  <div className="bg-green-50 border border-hecto-200 p-6 rounded-xl">
     <h4 className="text-green-900 font-semibold mb-3">✅ 성공 시나리오</h4>
     <ul className="text-green-800 text-sm space-y-2">
       <li>• 정상 포인트 결제</li>
@@ -829,7 +829,7 @@ A. 포인트 유효기간은 포인트 발급처의 정책에 따라 다릅니�
   
   <a href="/docs/pg/mobile-payment" className="block p-4 bg-white border-2 border-purple-100 hover:border-purple-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-purple-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-purple-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-purple-600 transition-colors">
         <span className="text-white text-lg">📱</span>
       </div>
       <span className="text-sm font-medium text-gray-900">휴대폰</span>

--- a/src/docs/pg/08-simple-payment.mdx
+++ b/src/docs/pg/08-simple-payment.mdx
@@ -13,25 +13,25 @@ import { FeatureGrid, TestScenario, ErrorGuide, NextSteps, DocumentFooter } from
     icon: "⚡",
     title: "빠른 결제",
     description: "간편한 인증으로 빠른 결제 완료, 복잡한 카드 정보 입력 불필요",
-    bgColor: "from-blue-50 to-blue-100",
-    borderColor: "border-blue-200",
-    iconBgColor: "bg-blue-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "🏢",
     title: "다양한 브랜드",
     description: "페이코, 카카오페이, 네이버페이, 삼성페이 등 주요 간편결제 지원",
-    bgColor: "from-green-50 to-green-100",
-    borderColor: "border-green-200",
-    iconBgColor: "bg-green-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "💳",
     title: "복합 결제",
     description: "포인트, 쿠폰, 카드 등 다양한 결제 수단을 조합하여 사용",
-    bgColor: "from-purple-50 to-purple-100",
-    borderColor: "border-purple-200",
-    iconBgColor: "bg-purple-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "🔄",
@@ -860,7 +860,7 @@ A. 네이버페이의 경우 자동으로 현금영수증이 발행되며, 발�
   
   <a href="/docs/pg/mobile-payment" className="block p-4 bg-white border-2 border-purple-100 hover:border-purple-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-purple-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-purple-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-purple-600 transition-colors">
         <span className="text-white text-lg">📱</span>
       </div>
       <span className="text-sm font-medium text-gray-900">휴대폰</span>
@@ -869,7 +869,7 @@ A. 네이버페이의 경우 자동으로 현금영수증이 발행되며, 발�
   
   <a href="/docs/pg/virtual-account" className="block p-4 bg-white border-2 border-green-100 hover:border-green-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-green-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-green-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-green-600 transition-colors">
         <span className="text-white text-lg">💰</span>
       </div>
       <span className="text-sm font-medium text-gray-900">가상계좌</span>
@@ -893,7 +893,7 @@ A. 네이버페이의 경우 자동으로 현금영수증이 발행되며, 발�
     간편결제 연동에 대한 추가 문의사항이 있으시나요?
   </p>
   <div className="flex justify-center space-x-4">
-    <a href="mailto:support@hectofinancial.com" className="inline-flex items-center px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors">
+    <a href="mailto:support@hectofinancial.com" className="inline-flex items-center px-4 py-2 bg-hecto-400 text-white rounded-lg hover:bg-blue-600 transition-colors">
       📧 기술지원 문의
     </a>
     <a href="/docs/pg/api-reference" className="inline-flex items-center px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors">

--- a/src/docs/pg/09-transaction-management.mdx
+++ b/src/docs/pg/09-transaction-management.mdx
@@ -13,25 +13,25 @@ import { FeatureGrid, TestScenario, ErrorGuide, NextSteps, DocumentFooter } from
     icon: "🔍",
     title: "실시간 거래 조회",
     description: "개별 거래의 상세 정보와 현재 상태를 실시간으로 확인",
-    bgColor: "from-blue-50 to-blue-100",
-    borderColor: "border-blue-200",
-    iconBgColor: "bg-blue-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "📋",
     title: "거래대사",
     description: "일자별 전체 거래 내역을 조회하여 거래 데이터 검증",
-    bgColor: "from-green-50 to-green-100",
-    borderColor: "border-green-200",
-    iconBgColor: "bg-green-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "💰",
     title: "정산대사",
     description: "정산 예정 거래와 수수료 정보를 확인하여 정산 관리",
-    bgColor: "from-purple-50 to-purple-100",
-    borderColor: "border-purple-200",
-    iconBgColor: "bg-purple-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   }
 ]} />
 
@@ -927,7 +927,7 @@ A. 승인구분 필드(apprType)에서 '0'은 승인, '1'은 취소를 의미합
   
   <a href="/docs/pg/credit-card" className="block p-4 bg-white border-2 border-blue-100 hover:border-blue-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-blue-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-blue-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-blue-600 transition-colors">
         <span className="text-white text-lg">💳</span>
       </div>
       <span className="text-sm font-medium text-gray-900">신용카드</span>
@@ -936,7 +936,7 @@ A. 승인구분 필드(apprType)에서 '0'은 승인, '1'은 취소를 의미합
   
   <a href="/docs/pg/simple-payment" className="block p-4 bg-white border-2 border-green-100 hover:border-green-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-green-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-green-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-green-600 transition-colors">
         <span className="text-white text-lg">⚡</span>
       </div>
       <span className="text-sm font-medium text-gray-900">간편결제</span>
@@ -951,7 +951,7 @@ A. 승인구분 필드(apprType)에서 '0'은 승인, '1'은 취소를 의미합
     거래 조회 및 관리에 대한 추가 문의사항이 있으시나요?
   </p>
   <div className="flex justify-center space-x-4">
-    <a href="mailto:support@hectofinancial.com" className="inline-flex items-center px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors">
+    <a href="mailto:support@hectofinancial.com" className="inline-flex items-center px-4 py-2 bg-hecto-400 text-white rounded-lg hover:bg-blue-600 transition-colors">
       📧 기술지원 문의
     </a>
     <a href="/docs/pg/api-reference" className="inline-flex items-center px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors">

--- a/src/docs/pg/10-developer-reference.mdx
+++ b/src/docs/pg/10-developer-reference.mdx
@@ -21,17 +21,17 @@ PG 결제 서비스 개발에 필요한 에러 코드, 카드사 식별자, 금�
     icon: "💳",
     title: "카드사 식별자",
     description: "모든 신용카드사의 고유 식별 코드와 명칭",
-    bgColor: "from-blue-50 to-blue-100",
-    borderColor: "border-blue-200",
-    iconBgColor: "bg-blue-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   },
   {
     icon: "🏦",
     title: "금융기관 코드",
     description: "은행, 증권사, 저축은행 등 모든 금융기관 코드",
-    bgColor: "from-green-50 to-green-100",
-    borderColor: "border-green-200",
-    iconBgColor: "bg-green-500"
+    bgColor: "from-hecto-50 to-hecto-100",
+    borderColor: "border-hecto-200",
+    iconBgColor: "bg-hecto-400"
   }
 ]} />
 
@@ -1276,7 +1276,7 @@ A. 새로운 서비스 추가 시 헥토파이낸셜에서 별도 공지와 함�
   
   <a href="/docs/pg/transaction-management" className="block p-4 bg-white border-2 border-blue-100 hover:border-blue-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-blue-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-blue-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-blue-600 transition-colors">
         <span className="text-white text-lg">📊</span>
       </div>
       <span className="text-sm font-medium text-gray-900">거래관리</span>
@@ -1285,7 +1285,7 @@ A. 새로운 서비스 추가 시 헥토파이낸셜에서 별도 공지와 함�
   
   <a href="/docs/pg/credit-card" className="block p-4 bg-white border-2 border-green-100 hover:border-green-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-green-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-green-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-green-600 transition-colors">
         <span className="text-white text-lg">💳</span>
       </div>
       <span className="text-sm font-medium text-gray-900">신용카드</span>
@@ -1294,7 +1294,7 @@ A. 새로운 서비스 추가 시 헥토파이낸셜에서 별도 공지와 함�
   
   <a href="/docs/pg/simple-payment" className="block p-4 bg-white border-2 border-purple-100 hover:border-purple-300 rounded-xl transition-colors group">
     <div className="text-center">
-      <div className="w-12 h-12 bg-purple-500 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-purple-600 transition-colors">
+      <div className="w-12 h-12 bg-hecto-400 rounded-lg flex items-center justify-center mx-auto mb-2 group-hover:bg-purple-600 transition-colors">
         <span className="text-white text-lg">⚡</span>
       </div>
       <span className="text-sm font-medium text-gray-900">간편결제</span>

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, lazy } from 'react'
 import { useParams, Link } from 'react-router-dom'
-import { ArrowLeft, Calendar, Clock, Tag } from 'lucide-react'
+import { ArrowLeft, Calendar, Clock } from 'lucide-react'
 
 // 블로그 포스트 메타데이터
 const blogPosts = [
@@ -58,7 +58,7 @@ const BlogDetailPage: React.FC = () => {
 
   // MDX 컴포넌트 동적 로드
   const MDXComponent = lazy(() => 
-    import(`../docs/blog/${blogPost.file}`).catch(() => ({
+    import(`../docs/blog/${blogPost.file}.mdx`).catch(() => ({
       default: () => (
         <div className="text-center py-12">
           <h2 className="text-xl font-semibold text-gray-900 mb-2">콘텐츠를 불러올 수 없습니다</h2>

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -14,8 +14,8 @@ const BlogPage: React.FC = () => {
       category: "가이드",
       icon: BookOpen,
       bgColor: "bg-hecto-50",
-      borderColor: "border-hecto-200",
-      iconColor: "text-hecto-600"
+      borderColor: "border-hecto-100",
+      iconColor: "text-hecto-500"
     },
     {
       id: "02-sample-article-2",
@@ -25,9 +25,9 @@ const BlogPage: React.FC = () => {
       readTime: "8분",
       category: "보안",
       icon: Shield,
-      bgColor: "bg-emerald-50",
-      borderColor: "border-emerald-200",
-      iconColor: "text-emerald-600"
+      bgColor: "bg-hecto-50",
+      borderColor: "border-hecto-100",
+      iconColor: "text-hecto-500"
     },
     {
       id: "03-sample-article-3",
@@ -37,9 +37,9 @@ const BlogPage: React.FC = () => {
       readTime: "6분",
       category: "기술",
       icon: Zap,
-      bgColor: "bg-violet-50",
-      borderColor: "border-violet-200",
-      iconColor: "text-violet-600"
+      bgColor: "bg-hecto-50",
+      borderColor: "border-hecto-100",
+      iconColor: "text-hecto-500"
     }
   ]
 
@@ -77,7 +77,7 @@ const BlogPage: React.FC = () => {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Hero Section */}
-      <div className="bg-gradient-to-br from-hecto-50 to-white border-b border-gray-200">
+      <div className="bg-hecto-50 border-b border-hecto-100">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
           <div className="text-center">
             <h1 className="text-4xl font-bold text-gray-900 mb-4">
@@ -102,10 +102,10 @@ const BlogPage: React.FC = () => {
                 <Link
                   key={post.id}
                   to={`/blog/${post.id}`}
-                  className={`${post.bgColor} ${post.borderColor} border rounded-xl p-6 hover:shadow-lg transition-all duration-200 group`}
+                  className={`${post.bgColor} ${post.borderColor} border rounded-2xl p-6 hover:shadow-md transition-all duration-200 group shadow-sm`}
                 >
                   <div className="flex items-center mb-4">
-                    <div className={`p-2 rounded-lg ${post.bgColor} ${post.iconColor}`}>
+                    <div className={`p-2 rounded-xl bg-hecto-100 ${post.iconColor}`}>
                       <IconComponent className="w-5 h-5" />
                     </div>
                     <span className="ml-3 text-sm font-medium text-gray-600">
@@ -145,11 +145,11 @@ const BlogPage: React.FC = () => {
               <Link
                 key={post.id}
                 to={`/blog/${post.id}`}
-                className="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-md transition-all duration-200 group flex flex-col sm:flex-row"
+                className="bg-hecto-50 rounded-2xl border border-hecto-100 p-6 hover:shadow-md transition-all duration-200 group flex flex-col sm:flex-row shadow-sm"
               >
                 <div className="flex-shrink-0 mb-4 sm:mb-0 sm:mr-6">
-                  <div className="w-full sm:w-48 h-32 bg-gradient-to-br from-gray-100 to-gray-200 rounded-lg flex items-center justify-center border border-gray-200">
-                    <Code className="w-8 h-8 text-gray-500" />
+                  <div className="w-full sm:w-48 h-32 bg-gradient-to-br from-hecto-100 to-hecto-200 rounded-xl flex items-center justify-center border border-hecto-200">
+                    <Code className="w-8 h-8 text-hecto-600" />
                   </div>
                 </div>
                 <div className="flex-1">


### PR DESCRIPTION
## 🎨 주요 변경사항

### 색상 통일
- 모든 PG 문서의 FeatureGrid 카드 색상을 헥토 오렌지 톤으로 통일
- 다양한 색상(blue, green, purple, emerald, violet) 제거
- 브랜드 일관성 및 세련된 디자인 구현

### 수정된 파일
- PG 문서 10개 파일의 FeatureGrid 색상 통일
- BlogDetailPage 빌드 오류 수정

## 🔧 빌드 상태
- ✅ TypeScript 컴파일 성공
- ✅ Vite 빌드 성공