### PR TITLE
fix: MDX 동적 로딩 오류 수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,16 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/docs/(.*)\\.mdx",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/plain"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## 문제점
Vercel 배포 환경에서 MDX 파일 동적 로딩 시 404 오류 발생

## 해결방법
- `import.meta.glob`을 사용한 동적 MDX 로딩으로 변경
- TypeScript 타입 안전성 개선
- vercel.json에 MDX 파일 헤더 설정 추가

## 변경사항
- `src/pages/DocsPage.tsx`: 동적 import 방식 개선
- `vercel.json`: MDX 파일 Content-Type 헤더 설정

## 테스트
- [x] 로컬 빌드 성공
- [x] TypeScript 컴파일 오류 해결