### PR TITLE
fix: 서비스 사이드바 자동 펼침 로직 개선

### DIFF
--- a/src/components/ServiceSidebar.tsx
+++ b/src/components/ServiceSidebar.tsx
@@ -36,7 +36,7 @@ interface ServiceSidebarProps {
 }
 
 export default function ServiceSidebar({ className }: ServiceSidebarProps) {
-  const [expandedItems, setExpandedItems] = useState<string[]>(['PG 결제'])
+  const [expandedItems, setExpandedItems] = useState<string[]>([])
   const location = useLocation()
 
   const toggleExpanded = (itemName: string) => {
@@ -49,11 +49,15 @@ export default function ServiceSidebar({ className }: ServiceSidebarProps) {
 
   // 현재 경로에 따라 자동으로 펼치기
   useEffect(() => {
+    const newExpandedItems: string[] = []
+    
     serviceNavigation.forEach(service => {
       if (service.children && service.children.some(child => location.pathname.startsWith(child.href))) {
-        setExpandedItems(prev => prev.includes(service.name) ? prev : [...prev, service.name])
+        newExpandedItems.push(service.name)
       }
     })
+    
+    setExpandedItems(newExpandedItems)
   }, [location.pathname])
 
   return (


### PR DESCRIPTION
## 문제점
서비스 페이지에서 PG 하위 문서 진입 시 PG 결제 메뉴가 항상 열려있어 사용자 경험이 좋지 않았음

## 해결방법
- 초기 상태를 빈 배열로 변경하여 기본적으로 모든 메뉴가 닫힌 상태로 시작
- 현재 경로에 해당하는 서비스만 자동으로 펼치도록 로직 개선
- 동적으로 모든 서비스를 순회하여 해당하는 서비스만 펼침

## 결과
- PG 하위 문서 진입 시에만 PG 결제 메뉴가 자동으로 열림
- 다른 서비스 문서 진입 시에는 해당 서비스만 열리고 나머지는 닫힘
- 새로운 서비스나 하위 메뉴 추가 시에도 자동으로 작동