### PR TITLE
fix: 서비스 메인 경로 접근 시 사이드바 자동 펼침 추가

### DIFF
--- a/src/components/ServiceSidebar.tsx
+++ b/src/components/ServiceSidebar.tsx
@@ -52,7 +52,11 @@ export default function ServiceSidebar({ className }: ServiceSidebarProps) {
     const newExpandedItems: string[] = []
     
     serviceNavigation.forEach(service => {
-      if (service.children && service.children.some(child => location.pathname.startsWith(child.href))) {
+      // 서비스 메인 경로이거나 하위 문서 경로인 경우 펼치기
+      if (service.children && (
+        location.pathname === service.href || 
+        service.children.some(child => location.pathname.startsWith(child.href))
+      )) {
         newExpandedItems.push(service.name)
       }
     })


### PR DESCRIPTION
## 문제점
네비바에서 서비스(예: PG 결제)를 클릭해서 메인 경로(/docs/pg)로 이동했을 때 사이드바 메뉴가 열리지 않았음

## 해결방법
서비스 사이드바 자동 펼침 로직에 서비스 메인 경로 조건 추가

## 변경사항
- 서비스 메인 경로() 접근 시에도 자동 펼침
- 기존 하위 문서 경로 조건과 함께 작동
- 모든 서비스(PG 결제, 내통장결제, 간편현금결제, 화이트라벨)에 적용

## 결과
- 네비바에서 PG 결제 클릭 → 사이드바 PG 결제 메뉴 자동 펼침
- PG 하위 문서 진입 → 사이드바 PG 결제 메뉴 자동 펼침
- 다른 서비스들도 동일하게 작동